### PR TITLE
feat: add support for k8s hosting

### DIFF
--- a/tutorontask/patches/k8s-deployments
+++ b/tutorontask/patches/k8s-deployments
@@ -30,7 +30,7 @@ spec:
           volumeMounts:
             - mountPath: /app/ontask
               name: docker-env
-            - mountPath: /app/ontask
+            - mountPath: /app/ontask/settings
               name: settings
       restartPolicy: Always
       volumes:
@@ -70,7 +70,7 @@ spec:
           volumeMounts:
             - mountPath: /app/ontask
               name: docker-env
-            - mountPath: /app/ontask
+            - mountPath: /app/ontask/settings
               name: settings
           command: ["supervisord"]
           args: ["-n", "-c", "/app/ontask/supervisor/supervisor.conf"]
@@ -82,7 +82,9 @@ spec:
         - name: settings
           configMap:
             name: ontask-settings
+{% endif %}
 
+{% if RUN_POSTGRES %}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -114,5 +116,5 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: ontask
-{% if RUN_ONTASK %}
+            claimName: postgres
+{% endif %}

--- a/tutorontask/patches/k8s-deployments
+++ b/tutorontask/patches/k8s-deployments
@@ -28,16 +28,24 @@ spec:
           ports:
             - containerPort: 8080
           volumeMounts:
-            - mountPath: /app/ontask
-              name: docker-env
-            - mountPath: /app/ontask/settings
-              name: settings
+            - name: docker-env
+              mountPath: /app/ontask/docker.env
+              subPath: docker.env
+            - name: base-settings
+              mountPath: /app/ontask/settings/base.py
+              subPath: base.py
+            - name: production-settings
+              mountPath: /app/ontask/settings/production.py
+              subPath: production.py
       restartPolicy: Always
       volumes:
         - name: docker-env
           configMap:
             name: ontask-env
-        - name: settings
+        - name: base-settings
+          configMap:
+            name: ontask-settings
+        - name: production-settings
           configMap:
             name: ontask-settings
 
@@ -68,10 +76,18 @@ spec:
               value: "true"
           image: {{ ONTASK_DOCKER_IMAGE }}
           volumeMounts:
-            - mountPath: /app/ontask
-              name: docker-env
-            - mountPath: /app/ontask/settings
-              name: settings
+            - name: docker-env
+              mountPath: /app/ontask/docker.env
+              subPath: docker.env
+            - name: base-settings
+              mountPath: /app/ontask/settings/base.py
+              subPath: base.py
+            - name: production-settings
+              mountPath: /app/ontask/settings/production.py
+              subPath: production.py
+            - name: supervisor
+              mountPath: /app/ontask/supervisor/supervisor.conf
+              subPath: supervisor.conf
           command: ["supervisord"]
           args: ["-n", "-c", "/app/ontask/supervisor/supervisor.conf"]
       restartPolicy: Always
@@ -79,9 +95,15 @@ spec:
         - name: docker-env
           configMap:
             name: ontask-env
-        - name: settings
+        - name: base-settings
           configMap:
             name: ontask-settings
+        - name: production-settings
+          configMap:
+            name: ontask-settings
+        - name: supervisor
+          configMap:
+            name: ontask-supervisor
 {% endif %}
 
 {% if RUN_POSTGRES %}
@@ -110,7 +132,7 @@ spec:
               value: {{ ONTASK_POSTGRES_ROOT_PASSWORD }}
           image: {{ ONTASK_POSTGRES_DOCKER_IMAGE }}
           volumeMounts:
-            - mountPath: /var/lib/postgresql/data
+            - mountPath: /var/lib/postgresql
               name: data
       restartPolicy: Always
       volumes:

--- a/tutorontask/patches/k8s-deployments
+++ b/tutorontask/patches/k8s-deployments
@@ -1,0 +1,116 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ontask
+  labels:
+    app.kubernetes.io/name: ontask
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ontask
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ontask
+    spec:
+      containers:
+        - name: ontask
+          env:
+            - name: ENV_FILENAME
+              value: "/app/ontask/docker.env"
+            - name: C_FORCE_ROOT
+              value: "true"
+          image: {{ ONTASK_DOCKER_IMAGE }}
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: /app/ontask
+              name: docker-env
+            - mountPath: /app/ontask
+              name: settings
+      restartPolicy: Always
+      volumes:
+        - name: docker-env
+          configMap:
+            name: ontask-env
+        - name: settings
+          configMap:
+            name: ontask-settings
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ontask-worker
+  labels:
+    app.kubernetes.io/name: ontask-worker
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ontask-worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ontask-worker
+    spec:
+      containers:
+        - name: ontask-worker
+          env:
+            - name: ENV_FILENAME
+              value: "/app/ontask/docker.env"
+            - name: C_FORCE_ROOT
+              value: "true"
+          image: {{ ONTASK_DOCKER_IMAGE }}
+          volumeMounts:
+            - mountPath: /app/ontask
+              name: docker-env
+            - mountPath: /app/ontask
+              name: settings
+          command: ["supervisord"]
+          args: ["-n", "-c", "/app/ontask/supervisor/supervisor.conf"]
+      restartPolicy: Always
+      volumes:
+        - name: docker-env
+          configMap:
+            name: ontask-env
+        - name: settings
+          configMap:
+            name: ontask-settings
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          env:
+            - name: POSTGRES_PASSWORD
+              value: {{ ONTASK_POSTGRES_ROOT_PASSWORD }}
+          image: {{ ONTASK_POSTGRES_DOCKER_IMAGE }}
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: data
+      restartPolicy: Always
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ontask

--- a/tutorontask/patches/k8s-deployments
+++ b/tutorontask/patches/k8s-deployments
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -114,3 +115,4 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: ontask
+{% if RUN_ONTASK %}

--- a/tutorontask/patches/k8s-jobs
+++ b/tutorontask/patches/k8s-jobs
@@ -22,15 +22,23 @@ spec:
           allowPrivilegeEscalation: false
           runAsUser: 0
         volumeMounts:
-          - mountPath: /app/ontask
-            name: docker-env
-          - mountPath: /app/ontask
-            name: settings
+          - name: docker-env
+            mountPath: /app/ontask/docker.env
+            subPath: docker.env
+          - name: base-settings
+            mountPath: /app/ontask/settings/base.py
+            subPath: base.py
+          - name: production-settings
+            mountPath: /app/ontask/settings/production.py
+            subPath: production.py
       volumes:
         - name: docker-env
           configMap:
             name: ontask-env
-        - name: settings
+        - name: base-settings
+          configMap:
+            name: ontask-settings
+        - name: production-settings
           configMap:
             name: ontask-settings
 {% endif %}
@@ -57,8 +65,8 @@ spec:
           allowPrivilegeEscalation: false
           runAsUser: 0
         volumeMounts:
-            - mountPath: /var/lib/postgresql/data
-              name: data
+          - mountPath: /var/lib/postgresql
+            name: data
       volumes:
         - name: data
           persistentVolumeClaim:

--- a/tutorontask/patches/k8s-jobs
+++ b/tutorontask/patches/k8s-jobs
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -32,7 +33,9 @@ spec:
         - name: settings
           configMap:
             name: ontask-settings
+{% endif %}
 
+{% if RUN_POSTGRES %}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -60,3 +63,4 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: ontask
+{% endif %}

--- a/tutorontask/patches/k8s-jobs
+++ b/tutorontask/patches/k8s-jobs
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ontask-job
+  labels:
+    app.kubernetes.io/component: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: ontask
+        env:
+          - name: ENV_FILENAME
+            value: "/app/ontask/docker.env"
+          - name: C_FORCE_ROOT
+            value: "true"
+        image: {{ ONTASK_DOCKER_IMAGE }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        volumeMounts:
+          - mountPath: /app/ontask
+            name: docker-env
+          - mountPath: /app/ontask
+            name: settings
+      volumes:
+        - name: docker-env
+          configMap:
+            name: ontask-env
+        - name: settings
+          configMap:
+            name: ontask-settings
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: postgres-job
+  labels:
+    app.kubernetes.io/component: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: postgres
+        env:
+          - name: POSTGRES_PASSWORD
+            value: {{ ONTASK_POSTGRES_ROOT_PASSWORD }}
+        image: {{ ONTASK_POSTGRES_DOCKER_IMAGE }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: ontask

--- a/tutorontask/patches/k8s-services
+++ b/tutorontask/patches/k8s-services
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ontask
+  labels:
+    app.kubernetes.io/name: ontask
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: ontask
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+spec:
+  ports:
+    - port: 5432
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: postgres

--- a/tutorontask/patches/k8s-services
+++ b/tutorontask/patches/k8s-services
@@ -7,13 +7,16 @@ metadata:
   labels:
     app.kubernetes.io/name: ontask
 spec:
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP
       name: http
   selector:
     app.kubernetes.io/name: ontask
+{% endif %}
 
+{% if RUN_POSTGRES %}
 ---
 apiVersion: v1
 kind: Service

--- a/tutorontask/patches/k8s-services
+++ b/tutorontask/patches/k8s-services
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 ---
 apiVersion: v1
 kind: Service
@@ -27,3 +28,4 @@ spec:
       name: http
   selector:
     app.kubernetes.io/name: postgres
+{% endif %}

--- a/tutorontask/patches/k8s-volumes
+++ b/tutorontask/patches/k8s-volumes
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ontask
+  labels:
+    app.kubernetes.io/component: volume
+    app.kubernetes.io/name: ontask
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/tutorontask/patches/k8s-volumes
+++ b/tutorontask/patches/k8s-volumes
@@ -1,12 +1,12 @@
-{% if RUN_ONTASK %}
+{% if RUN_POSTGRES %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: ontask
+  name: postgres
   labels:
     app.kubernetes.io/component: volume
-    app.kubernetes.io/name: ontask
+    app.kubernetes.io/name: postgres
 spec:
   accessModes:
     - ReadWriteOnce

--- a/tutorontask/patches/k8s-volumes
+++ b/tutorontask/patches/k8s-volumes
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -12,3 +13,4 @@ spec:
   resources:
     requests:
       storage: 5Gi
+{% endif %}

--- a/tutorontask/patches/kustomization-configmapgenerator
+++ b/tutorontask/patches/kustomization-configmapgenerator
@@ -1,0 +1,13 @@
+- name: ontask-env
+  files:{% for file in "ontask/apps/docker/production/"|walk_templates %}
+  - plugins/{{ file }}{% endfor %}
+  options:
+    labels:
+        app.kubernetes.io/name: ontask
+
+- name: ontask-settings
+  files:{% for file in "ontask/apps/settings/"|walk_templates %}
+  - plugins/{{ file }}{% endfor %}
+  options:
+    labels:
+        app.kubernetes.io/name: ontask

--- a/tutorontask/patches/kustomization-configmapgenerator
+++ b/tutorontask/patches/kustomization-configmapgenerator
@@ -7,7 +7,14 @@
         app.kubernetes.io/name: ontask
 
 - name: ontask-settings
-  files:{% for file in "ontask/apps/settings/"|walk_templates %}
+  files:{% for file in "ontask/apps/service/settings/"|walk_templates %}
+  - plugins/{{ file }}{% endfor %}
+  options:
+    labels:
+        app.kubernetes.io/name: ontask
+
+- name: ontask-supervisor
+  files:{% for file in "ontask/apps/supervisor/"|walk_templates %}
   - plugins/{{ file }}{% endfor %}
   options:
     labels:

--- a/tutorontask/patches/kustomization-configmapgenerator
+++ b/tutorontask/patches/kustomization-configmapgenerator
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 - name: ontask-env
   files:{% for file in "ontask/apps/docker/production/"|walk_templates %}
   - plugins/{{ file }}{% endfor %}
@@ -11,3 +12,4 @@
   options:
     labels:
         app.kubernetes.io/name: ontask
+{% endif %}

--- a/tutorontask/patches/local-docker-compose-jobs-services
+++ b/tutorontask/patches/local-docker-compose-jobs-services
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 ontask-job:
   image: {{ ONTASK_DOCKER_IMAGE }}
   ports:
@@ -33,3 +34,4 @@ postgres-job:
   image: {{ ONTASK_POSTGRES_DOCKER_IMAGE }}
   depends_on:
     - postgres
+{% endif %}

--- a/tutorontask/patches/local-docker-compose-services
+++ b/tutorontask/patches/local-docker-compose-services
@@ -1,3 +1,4 @@
+{% if RUN_ONTASK %}
 ontask:
   image: {{ ONTASK_DOCKER_IMAGE }}
   ports:
@@ -39,3 +40,4 @@ postgres:
   volumes:
     - ../../data/ontask/postgres/data:/var/lib/postgresql/data
   restart: unless-stopped
+{% endif %}

--- a/tutorontask/plugin.py
+++ b/tutorontask/plugin.py
@@ -48,6 +48,7 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         ("ONTASK_EMAIL_ACTION_NOTIFICATION_SENDER", "admin@mail.com"),
         ("ONTASK_POSTGRES_ROOT_USERNAME", "postgres"),
         ("ONTASK_POSTGRES_ROOT_PASSWORD", "{{ 8|random_string }}"),
+        ("RUN_ONTASK", True),
     ]
 )
 

--- a/tutorontask/plugin.py
+++ b/tutorontask/plugin.py
@@ -30,6 +30,8 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("ONTASK_REDIS_URL", "redis://{{ REDIS_HOST }}:{{ REDIS_PORT }}"),
         ("ONTASK_APP_VERSION", "Version_10_3"),
         ("ONTASK_EXTRA_PRODUCTION_SETTINGS", ""),
+        ("RUN_ONTASK", True),
+        ("RUN_POSTGRES", True),
     ]
 )
 
@@ -48,7 +50,6 @@ hooks.Filters.CONFIG_UNIQUE.add_items(
         ("ONTASK_EMAIL_ACTION_NOTIFICATION_SENDER", "admin@mail.com"),
         ("ONTASK_POSTGRES_ROOT_USERNAME", "postgres"),
         ("ONTASK_POSTGRES_ROOT_PASSWORD", "{{ 8|random_string }}"),
-        ("RUN_ONTASK", True),
     ]
 )
 


### PR DESCRIPTION
### Description
This PR adds support for k8s hosting to the OnTask Tutor service.

### How to test
1. Install tutor-contrib-ontask: `pip install git+https://github.com/eduNEXT/tutor-contrib-ontask.git`
2. Generate new templates: `tutor config save`
3. Deploy the service: `tutor k8s apply`