### PR TITLE
fix: add recommended python driver DBAPI for mysql

### DIFF
--- a/tutorontask/plugin.py
+++ b/tutorontask/plugin.py
@@ -25,7 +25,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("ONTASK_DB_NAME", "ontask"),
         ("ONTASK_DB_USER", "ontask"),
         ("ONTASK_POSTGRES_HOST", "postgres"),
-        ("ONTASK_DOCKER_IMAGE", "docker.io/edunext/ontask:0.3.0"),
+        ("ONTASK_DOCKER_IMAGE", "docker.io/edunext/ontask:0.3.1"),
         ("ONTASK_POSTGRES_DOCKER_IMAGE", "postgres:14.12-bullseye"),
         ("ONTASK_DATABASE_URL", "postgres://{{ ONTASK_DB_USER }}:{{ ONTASK_POSTGRES_PASSWORD }}@postgres:5432/{{ ONTASK_DB_NAME }}"),
         ("ONTASK_REDIS_URL", "redis://{{ REDIS_HOST }}:{{ REDIS_PORT }}"),

--- a/tutorontask/templates/ontask/build/ontask/Dockerfile
+++ b/tutorontask/templates/ontask/build/ontask/Dockerfile
@@ -58,7 +58,6 @@ ENV VIRTUAL_ENV /app/venv/
 RUN pip install -r /app/ontask/requirements/base.txt
 RUN pip install -r /app/ontask/requirements/essential.txt
 RUN pip install uwsgi==2.0.21
-RUN pip install mysqlclient==2.2.4
 
 # Copy the default uWSGI configuration
 COPY settings/uwsgi.ini .


### PR DESCRIPTION
### Description

Remove `mysqlclient` in favor of default ontask driver `sqlalchemy`. The reason behind is that On Task doesn't recognize `mysqlclient` driver:

` Unable to obtain data: Can't load plugin: sqlalchemy.dialects:mysql.mysqlclient `
