### PR TITLE
fix: mount data volume instead of postgresql

### DIFF
--- a/tutorontask/patches/k8s-deployments
+++ b/tutorontask/patches/k8s-deployments
@@ -171,9 +171,16 @@ spec:
           env:
             - name: POSTGRES_PASSWORD
               value: {{ ONTASK_POSTGRES_ROOT_PASSWORD }}
+            # Fixes:
+            # initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
+            # It contains a lost+found directory, perhaps due to it being a mount point.
+            # Using a mount point directly as the data directory is not recommended.
+            # Create a subdirectory under the mount point.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           image: {{ ONTASK_POSTGRES_DOCKER_IMAGE }}
           volumeMounts:
-            - mountPath: /var/lib/postgresql
+            - mountPath: /var/lib/postgresql/data
               name: data
       restartPolicy: Always
       volumes:


### PR DESCRIPTION
### Description

This PR fixes an issue with the permissions of the PostgreSQL deployment which causes a bug that deletes the entire database on every restart.